### PR TITLE
Hide Windows bootstrap process from taskbar

### DIFF
--- a/kernel/boot.js
+++ b/kernel/boot.js
@@ -36,6 +36,34 @@ if (IS_SEA) {
 
 const IS_DEV = process.argv.includes("--dev");
 
+// On Windows SEA builds, relaunch the kernel in a hidden detached process so
+// the bootstrap console/taskbar entry disappears and Chromium is the only
+// visible app icon after startup.
+function relaunchBackgroundKernelIfNeeded() {
+  const shouldRelaunch =
+    process.platform === "win32" &&
+    IS_SEA &&
+    !IS_DEV &&
+    process.env.RONI_BACKGROUND_KERNEL !== "1";
+
+  if (!shouldRelaunch) return;
+
+  const child = spawn(process.execPath, process.argv.slice(1), {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+    env: {
+      ...process.env,
+      RONI_BACKGROUND_KERNEL: "1",
+    },
+  });
+
+  child.unref();
+  process.exit(0);
+}
+
+relaunchBackgroundKernelIfNeeded();
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 function loadConfig() {


### PR DESCRIPTION
### Motivation
- Ensure Chromium is the only visible taskbar/app-switcher entry on Windows SEA builds by preventing the bootstrap kernel process from appearing as a separate taskbar icon.

### Description
- Added `relaunchBackgroundKernelIfNeeded` to `kernel/boot.js` which, on `win32` + `IS_SEA` and not `--dev`, respawns the executable as a detached, hidden process and sets `RONI_BACKGROUND_KERNEL=1` to avoid loops, then exits the original process.

### Testing
- Ran `node --check kernel/boot.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c07283fc8321a5498d1c02f4aae4)