### PR TITLE
Improve Windows background handling, add system tray, and harden Chromium lifecycle

### DIFF
--- a/kernel/boot.js
+++ b/kernel/boot.js
@@ -4,11 +4,9 @@
 
 import {
   readFileSync,
-  writeFileSync,
   existsSync,
   createReadStream,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { spawn, execSync } from "node:child_process";
 import { createServer } from "node:http";
 import { resolve, dirname, join, extname } from "node:path";
@@ -22,39 +20,33 @@ import { SessionService } from "./auth/session.js";
 import { compositorFiles as EMBEDDED_COMPOSITOR } from "roni:compositor";
 
 // ── ROOT resolution ───────────────────────────────────────────────────────────
-// SEA detection: in a bundled CJS SEA, import.meta.url is the exe path (not file:)
-// process.argv[0] is always the actual running exe on all platforms.
-const IS_SEA = !import.meta.url?.startsWith("file:");
+const IS_DEV = process.argv.includes("--dev");
+const IS_BACKGROUND = process.env.RONI_BACKGROUND === "1";
+const IS_NODE_BINARY = /(^|[\/])node(\.exe)?$/i.test(process.execPath);
+const IS_SEA = !IS_DEV && !IS_NODE_BINARY && process.argv[0] === process.execPath;
+
 let ROOT;
+const RUNTIME = { chromium: null };
+
 if (IS_SEA) {
-  // argv[0] = full exe path e.g. C:\Users\Augment\Downloads\roni.exe
-  ROOT = dirname(resolve(process.argv[0]));
+  ROOT = dirname(resolve(process.execPath));
 } else {
   // Dev: kernel/boot.js → go up one level to project root
   ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 }
 
-const IS_DEV = process.argv.includes("--dev");
-
-// On Windows SEA builds, relaunch the kernel in a hidden detached process so
-// the bootstrap console/taskbar entry disappears and Chromium is the only
-// visible app icon after startup.
-function relaunchBackgroundKernelIfNeeded() {
-  const shouldRelaunch =
-    process.platform === "win32" &&
-    IS_SEA &&
-    !IS_DEV &&
-    process.env.RONI_BACKGROUND_KERNEL !== "1";
+function relaunchBackgroundIfNeeded() {
+  const shouldRelaunch = IS_SEA && !IS_DEV && !IS_BACKGROUND;
 
   if (!shouldRelaunch) return;
 
   const child = spawn(process.execPath, process.argv.slice(1), {
     detached: true,
     stdio: "ignore",
-    windowsHide: true,
+    windowsHide: process.platform === "win32",
     env: {
       ...process.env,
-      RONI_BACKGROUND_KERNEL: "1",
+      RONI_BACKGROUND: "1",
     },
   });
 
@@ -62,7 +54,66 @@ function relaunchBackgroundKernelIfNeeded() {
   process.exit(0);
 }
 
-relaunchBackgroundKernelIfNeeded();
+// On Windows SEA builds, hide this process console window in-place.
+// This avoids creating a second bootstrap process that can leave an extra
+// taskbar entry while still keeping Chromium as the only visible window.
+function hideWindowsConsoleIfNeeded() {
+  const shouldHide = process.platform === "win32" && IS_SEA && !IS_DEV;
+  if (!shouldHide) return;
+
+  try {
+    execSync(
+      `powershell -NoProfile -ExecutionPolicy Bypass -Command "$sig='[DllImport(\"kernel32.dll\")]public static extern System.IntPtr GetConsoleWindow();[DllImport(\"user32.dll\")]public static extern bool ShowWindow(System.IntPtr hWnd,int nCmdShow);';Add-Type -Name Win32 -Namespace Roni -MemberDefinition $sig | Out-Null;$h=[Roni.Win32]::GetConsoleWindow();if($h -ne [System.IntPtr]::Zero){ [Roni.Win32]::ShowWindow($h,0) | Out-Null }"`,
+      { stdio: "ignore", windowsHide: true }
+    );
+  } catch {
+    // Non-fatal fallback: continue with visible console if hiding fails.
+  }
+}
+
+relaunchBackgroundIfNeeded();
+hideWindowsConsoleIfNeeded();
+
+
+async function startSystemTrayIfAvailable(runtime) {
+  if (IS_DEV) return null;
+
+  try {
+    const { SysTray } = await import("node-systray");
+    const trayIcon =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+AP9KobjigAAAABJRU5ErkJggg==";
+
+    const systray = new SysTray({
+      menu: {
+        icon: trayIcon,
+        title: "Roni",
+        tooltip: "Roni OS",
+        items: [
+          { title: "Restart Chromium", tooltip: "Restart Chromium", enabled: true },
+          { title: "Quit Roni", tooltip: "Quit", enabled: true },
+        ],
+      },
+      debug: false,
+      copyDir: true,
+    });
+
+    systray.onClick(({ item }) => {
+      if (!item?.title) return;
+      if (item.title === "Restart Chromium" && runtime.chromium) {
+        runtime.chromium.kill();
+        return;
+      }
+      if (item.title === "Quit Roni") {
+        process.exit(0);
+      }
+    });
+
+    return systray;
+  } catch (err) {
+    console.warn(`[boot] node-systray unavailable: ${err.message}`);
+    return null;
+  }
+}
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -234,28 +285,32 @@ function spawnChromium(config, port) {
   }
   const args = buildChromiumArgs(config, port);
   console.log(`[boot] Launching: ${bin.split(/[/\\]/).pop()} ${args[0]}`);
+  const isWin = process.platform === "win32";
   const child = spawn(bin, args, {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: isWin ? "ignore" : ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...(process.env.DISPLAY ? {} : { DISPLAY: ":0" }) },
     detached: false,
-    windowsHide: false,
+    windowsHide: isWin,
   });
-  child.stdout.on("data", (d) => process.stdout.write(`[chromium] ${d}`));
-  child.stderr.on("data", (d) => {
-    const msg = d.toString();
-    if (
-      [
-        "Failed to connect",
-        "Missing X server",
-        "MESA",
-        "dri",
-        "DevTools",
-        "Gtk",
-      ].some((s) => msg.includes(s))
-    )
-      return;
-    process.stderr.write(`[chromium:err] ${msg}`);
-  });
+  if (!isWin) {
+    child.stdout.on("data", (d) => process.stdout.write(`[chromium] ${d}`));
+    child.stderr.on("data", (d) => {
+      const msg = d.toString();
+      if (
+        [
+          "Failed to connect",
+          "Missing X server",
+          "MESA",
+          "dri",
+          "DevTools",
+          "Gtk",
+        ].some((s) => msg.includes(s))
+      )
+        return;
+      process.stderr.write(`[chromium:err] ${msg}`);
+    });
+  }
+  RUNTIME.chromium = child;
   const spawnTime = Date.now();
 
   child.on("exit", (code, signal) => {
@@ -271,10 +326,14 @@ function spawnChromium(config, port) {
         "[boot] Chrome exited in under 3s. Is another Roni already running?"
       );
       console.error("[boot] Retrying in 3s with fresh profile...");
-      setTimeout(() => spawnChromium(config, port), 3000);
+      setTimeout(() => {
+        RUNTIME.chromium = spawnChromium(config, port);
+      }, 3000);
     } else if (code !== 0 && code !== null) {
       console.log("[boot] Chrome crashed — restarting in 2s...");
-      setTimeout(() => spawnChromium(config, port), 2000);
+      setTimeout(() => {
+        RUNTIME.chromium = spawnChromium(config, port);
+      }, 2000);
     } else {
       // Clean exit after normal use — user closed the window
       console.log("[boot] Chrome closed cleanly. Shutting down.");
@@ -283,7 +342,9 @@ function spawnChromium(config, port) {
   });
   child.on("error", (err) => {
     console.error(`[boot] Chrome launch failed: ${err.message}`);
-    setTimeout(() => spawnChromium(config, port), 3000);
+    setTimeout(() => {
+      RUNTIME.chromium = spawnChromium(config, port);
+    }, 3000);
   });
   return child;
 }
@@ -365,35 +426,6 @@ function startCompositorServer(config) {
 
 async function main() {
   process.title = "Roni";
-
-  // On Windows SEA: relaunch via wscript with windowStyle=0 (hidden console).
-  // --no-hide prevents the relaunched copy from repeating this.
-  if (
-    process.platform === "win32" &&
-    IS_SEA &&
-    !process.argv.includes("--no-hide")
-  ) {
-    try {
-      const vbsPath = join(tmpdir(), "roni-hide.vbs");
-      const exeArgs = [process.argv[0], "--no-hide", ...process.argv.slice(2)]
-        .map((a) => '"' + a.replace(/"/g, '""') + '"')
-        .join(" ");
-      writeFileSync(
-        vbsPath,
-        'Set sh = CreateObject("WScript.Shell")\r\n' +
-          "sh.Run " +
-          JSON.stringify(exeArgs) +
-          ", 0, False\r\n"
-      );
-      spawn("wscript.exe", [vbsPath], {
-        detached: true,
-        stdio: "ignore",
-      }).unref();
-      process.exit(0);
-    } catch {
-      /* non-fatal — app runs with visible console */
-    }
-  }
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
   console.log("  Roni OS — Booting");
   console.log(
@@ -415,7 +447,8 @@ async function main() {
     console.log("[boot] DEV mode — open http://localhost:5173");
   }
 
-  spawnChromium(config, port);
+  RUNTIME.chromium = spawnChromium(config, port);
+  await startSystemTrayIfAvailable(RUNTIME);
 
   // Keep the event loop alive — the HTTP server and Chrome process do this
   // naturally, but be explicit for SEA on Windows

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -129,6 +129,7 @@ export default {
     "perf_hooks",
     "inspector",
     "module",
+    "node-systray",
   ],
 
   plugins: [


### PR DESCRIPTION
### Motivation

- Reduce visible bootstrap consoles on Windows SEA builds and avoid duplicate taskbar entries while keeping Chromium as the primary UI process. 
- Add a lightweight system tray for user controls (restart/quit) when available. 
- Make Chromium spawn/restart behavior more robust and track the running instance to enable programmatic control.

### Description

- Replace previous VBS-based relaunch with refined environment flags and two steps: `relaunchBackgroundIfNeeded` to detach when appropriate and `hideWindowsConsoleIfNeeded` which calls a PowerShell snippet to hide the console on Windows SEA builds. 
- Introduce runtime flags `IS_DEV`, `IS_BACKGROUND`, `IS_NODE_BINARY`, and compute `IS_SEA` more robustly, and add a `RUNTIME` object to track the spawned Chromium process. 
- Add `startSystemTrayIfAvailable` which dynamically imports `node-systray` (disabled in `--dev`) and exposes menu actions for restarting Chromium and quitting the app. 
- Update `spawnChromium` to set `RUNTIME.chromium`, adjust stdio/windowsHide behavior based on platform, stream Chromium logs only on non-Windows, and ensure restart retries update `RUNTIME.chromium`. 
- Remove unused imports (`writeFileSync`, `tmpdir`) and add `node-systray` to the Rollup external list so the tray module is not bundled. 
- Wire `RUNTIME.chromium` assignment in `main` and await `startSystemTrayIfAvailable` when available, and keep the event loop alive explicitly for SEA on Windows.

### Testing

- Built the bundle with the project rollup configuration by running `rollup -c`, and the build completed successfully. 
- Ran the repository's automated test suite via `npm test`, and all tests passed. 
- Verified that Chromium process lifecycle restart logic updates `RUNTIME.chromium` by executing the boot entry in a CI-like environment and observing restart behavior through the process exit handlers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c44f6bb883218e81b4bcd4dabbdc)