### PR TITLE
Add system tray, refine SEA/dev/background detection, and improve Chromium lifecycle

### DIFF
--- a/kernel/boot.js
+++ b/kernel/boot.js
@@ -4,11 +4,9 @@
 
 import {
   readFileSync,
-  writeFileSync,
   existsSync,
   createReadStream,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { spawn, execSync } from "node:child_process";
 import { createServer } from "node:http";
 import { resolve, dirname, join, extname } from "node:path";
@@ -22,39 +20,33 @@ import { SessionService } from "./auth/session.js";
 import { compositorFiles as EMBEDDED_COMPOSITOR } from "roni:compositor";
 
 // ── ROOT resolution ───────────────────────────────────────────────────────────
-// SEA detection: in a bundled CJS SEA, import.meta.url is the exe path (not file:)
-// process.argv[0] is always the actual running exe on all platforms.
-const IS_SEA = !import.meta.url?.startsWith("file:");
+const IS_DEV = process.argv.includes("--dev");
+const IS_BACKGROUND = process.env.RONI_BACKGROUND === "1";
+const IS_NODE_BINARY = /(^|[\/])node(\.exe)?$/i.test(process.execPath);
+const IS_SEA = !IS_DEV && !IS_NODE_BINARY && process.argv[0] === process.execPath;
+
 let ROOT;
+const RUNTIME = { chromium: null };
+
 if (IS_SEA) {
-  // argv[0] = full exe path e.g. C:\Users\Augment\Downloads\roni.exe
-  ROOT = dirname(resolve(process.argv[0]));
+  ROOT = dirname(resolve(process.execPath));
 } else {
   // Dev: kernel/boot.js → go up one level to project root
   ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 }
 
-const IS_DEV = process.argv.includes("--dev");
-
-// On Windows SEA builds, relaunch the kernel in a hidden detached process so
-// the bootstrap console/taskbar entry disappears and Chromium is the only
-// visible app icon after startup.
-function relaunchBackgroundKernelIfNeeded() {
-  const shouldRelaunch =
-    process.platform === "win32" &&
-    IS_SEA &&
-    !IS_DEV &&
-    process.env.RONI_BACKGROUND_KERNEL !== "1";
+function relaunchBackgroundIfNeeded() {
+  const shouldRelaunch = IS_SEA && !IS_DEV && !IS_BACKGROUND;
 
   if (!shouldRelaunch) return;
 
   const child = spawn(process.execPath, process.argv.slice(1), {
     detached: true,
     stdio: "ignore",
-    windowsHide: true,
+    windowsHide: process.platform === "win32",
     env: {
       ...process.env,
-      RONI_BACKGROUND_KERNEL: "1",
+      RONI_BACKGROUND: "1",
     },
   });
 
@@ -62,7 +54,47 @@ function relaunchBackgroundKernelIfNeeded() {
   process.exit(0);
 }
 
-relaunchBackgroundKernelIfNeeded();
+relaunchBackgroundIfNeeded();
+
+async function startSystemTrayIfAvailable(runtime) {
+  if (IS_DEV) return null;
+
+  try {
+    const { SysTray } = await import("node-systray");
+    const trayIcon =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+AP9KobjigAAAABJRU5ErkJggg==";
+
+    const systray = new SysTray({
+      menu: {
+        icon: trayIcon,
+        title: "Roni",
+        tooltip: "Roni OS",
+        items: [
+          { title: "Restart Chromium", tooltip: "Restart Chromium", enabled: true },
+          { title: "Quit Roni", tooltip: "Quit", enabled: true },
+        ],
+      },
+      debug: false,
+      copyDir: true,
+    });
+
+    systray.onClick(({ item }) => {
+      if (!item?.title) return;
+      if (item.title === "Restart Chromium" && runtime.chromium) {
+        runtime.chromium.kill();
+        return;
+      }
+      if (item.title === "Quit Roni") {
+        process.exit(0);
+      }
+    });
+
+    return systray;
+  } catch (err) {
+    console.warn(`[boot] node-systray unavailable: ${err.message}`);
+    return null;
+  }
+}
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -234,28 +266,32 @@ function spawnChromium(config, port) {
   }
   const args = buildChromiumArgs(config, port);
   console.log(`[boot] Launching: ${bin.split(/[/\\]/).pop()} ${args[0]}`);
+  const isWin = process.platform === "win32";
   const child = spawn(bin, args, {
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: isWin ? "ignore" : ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...(process.env.DISPLAY ? {} : { DISPLAY: ":0" }) },
     detached: false,
-    windowsHide: false,
+    windowsHide: isWin,
   });
-  child.stdout.on("data", (d) => process.stdout.write(`[chromium] ${d}`));
-  child.stderr.on("data", (d) => {
-    const msg = d.toString();
-    if (
-      [
-        "Failed to connect",
-        "Missing X server",
-        "MESA",
-        "dri",
-        "DevTools",
-        "Gtk",
-      ].some((s) => msg.includes(s))
-    )
-      return;
-    process.stderr.write(`[chromium:err] ${msg}`);
-  });
+  if (!isWin) {
+    child.stdout.on("data", (d) => process.stdout.write(`[chromium] ${d}`));
+    child.stderr.on("data", (d) => {
+      const msg = d.toString();
+      if (
+        [
+          "Failed to connect",
+          "Missing X server",
+          "MESA",
+          "dri",
+          "DevTools",
+          "Gtk",
+        ].some((s) => msg.includes(s))
+      )
+        return;
+      process.stderr.write(`[chromium:err] ${msg}`);
+    });
+  }
+  RUNTIME.chromium = child;
   const spawnTime = Date.now();
 
   child.on("exit", (code, signal) => {
@@ -271,10 +307,14 @@ function spawnChromium(config, port) {
         "[boot] Chrome exited in under 3s. Is another Roni already running?"
       );
       console.error("[boot] Retrying in 3s with fresh profile...");
-      setTimeout(() => spawnChromium(config, port), 3000);
+      setTimeout(() => {
+        RUNTIME.chromium = spawnChromium(config, port);
+      }, 3000);
     } else if (code !== 0 && code !== null) {
       console.log("[boot] Chrome crashed — restarting in 2s...");
-      setTimeout(() => spawnChromium(config, port), 2000);
+      setTimeout(() => {
+        RUNTIME.chromium = spawnChromium(config, port);
+      }, 2000);
     } else {
       // Clean exit after normal use — user closed the window
       console.log("[boot] Chrome closed cleanly. Shutting down.");
@@ -283,7 +323,9 @@ function spawnChromium(config, port) {
   });
   child.on("error", (err) => {
     console.error(`[boot] Chrome launch failed: ${err.message}`);
-    setTimeout(() => spawnChromium(config, port), 3000);
+    setTimeout(() => {
+      RUNTIME.chromium = spawnChromium(config, port);
+    }, 3000);
   });
   return child;
 }
@@ -365,35 +407,6 @@ function startCompositorServer(config) {
 
 async function main() {
   process.title = "Roni";
-
-  // On Windows SEA: relaunch via wscript with windowStyle=0 (hidden console).
-  // --no-hide prevents the relaunched copy from repeating this.
-  if (
-    process.platform === "win32" &&
-    IS_SEA &&
-    !process.argv.includes("--no-hide")
-  ) {
-    try {
-      const vbsPath = join(tmpdir(), "roni-hide.vbs");
-      const exeArgs = [process.argv[0], "--no-hide", ...process.argv.slice(2)]
-        .map((a) => '"' + a.replace(/"/g, '""') + '"')
-        .join(" ");
-      writeFileSync(
-        vbsPath,
-        'Set sh = CreateObject("WScript.Shell")\r\n' +
-          "sh.Run " +
-          JSON.stringify(exeArgs) +
-          ", 0, False\r\n"
-      );
-      spawn("wscript.exe", [vbsPath], {
-        detached: true,
-        stdio: "ignore",
-      }).unref();
-      process.exit(0);
-    } catch {
-      /* non-fatal — app runs with visible console */
-    }
-  }
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
   console.log("  Roni OS — Booting");
   console.log(
@@ -415,7 +428,8 @@ async function main() {
     console.log("[boot] DEV mode — open http://localhost:5173");
   }
 
-  spawnChromium(config, port);
+  RUNTIME.chromium = spawnChromium(config, port);
+  await startSystemTrayIfAvailable(RUNTIME);
 
   // Keep the event loop alive — the HTTP server and Chrome process do this
   // naturally, but be explicit for SEA on Windows

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -129,6 +129,7 @@ export default {
     "perf_hooks",
     "inspector",
     "module",
+    "node-systray",
   ],
 
   plugins: [


### PR DESCRIPTION
### Motivation

- Improve platform detection and background relaunch behavior so the kernel behaves correctly in dev, packaged (SEA), and node-binary contexts.
- Provide a native system tray (when available) to allow quick actions like restarting Chromium or quitting the OS.
- Make Chromium process management more robust by tracking the child process and ensuring respawns update that reference.

### Description

- Introduce `IS_DEV`, `IS_BACKGROUND`, and `IS_NODE_BINARY` flags and refine `IS_SEA` and `ROOT` resolution logic to better detect runtime contexts.
- Replace the previous Windows VBS relaunch hack with a unified `relaunchBackgroundIfNeeded` that sets `RONI_BACKGROUND` and uses `windowsHide` appropriately.
- Add a `RUNTIME` object to store runtime state and set `RUNTIME.chromium` when spawning Chromium so external controls can reference it.
- Add `startSystemTrayIfAvailable` which lazily imports `node-systray`, creates a tray menu with `Restart Chromium` and `Quit Roni` actions, and wires actions to `RUNTIME.chromium`; also add `node-systray` to rollup externals.
- Update `spawnChromium` to vary `stdio` and `windowsHide` per-platform, conditionally log stdout/stderr only on non-Windows platforms, and ensure respawn handlers assign new child to `RUNTIME.chromium`.
- Remove the old Windows `tmpdir`/VBS hide code and await the tray initialization from `main` while keeping the event loop alive explicitly for SEA cases.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c44f6bb883218e81b4bcd4dabbdc)